### PR TITLE
Debug devcontainer configuration error

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,10 +1,8 @@
 {
   "name": "Fullstack (PHP + Node)",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+  "image": "mcr.microsoft.com/devcontainers/php:8.3",
   "features": {
-    "ghcr.io/devcontainers/features/php:1": {
-      "version": "8.3"
-    },
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
     "ghcr.io/devcontainers/features/mysql-client:1": {}
   },
   "customizations": {
@@ -17,5 +15,5 @@
     }
   },
   "remoteUser": "vscode",
-  "postCreateCommand": "npm install -g pnpm && cd apps/web && pnpm install"
+  "postCreateCommand": "npm -w apps/web install"
 }


### PR DESCRIPTION
Resolve Codespaces recovery mode error by fixing devcontainer image/feature conflicts and simplifying post-create command.

The previous devcontainer configuration used a Node.js base image with a PHP feature, which caused conflicts and container build failures. This PR switches to a PHP base image (`php:8.3`) and adds Node.js as a feature (`node:1`) for better compatibility. The `postCreateCommand` was also adjusted to correctly install `npm` dependencies for the `apps/web` workspace.

---
<a href="https://cursor.com/background-agent?bcId=bc-b3e80c07-ffc2-40f6-8a8d-a2a1ac31a3f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b3e80c07-ffc2-40f6-8a8d-a2a1ac31a3f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

