### PR TITLE
Investigate recurring issue

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,11 +2,10 @@
   "name": "Fullstack (PHP + Node)",
   "image": "mcr.microsoft.com/devcontainers/php:8.3",
   "features": {
-    "ghcr.io/devcontainers/features/node:1": { "version": "20" },
-    "ghcr.io/devcontainers/features/mysql-client:1": {}
+    "ghcr.io/devcontainers/features/node:1": { "version": "20" }
   },
   "remoteUser": "vscode",
-  "postCreateCommand": "npm install -g pnpm && cd apps/web && pnpm install",
+  "postCreateCommand": "sudo apt-get update && sudo apt-get install -y mariadb-client && npm install -g pnpm && cd apps/web && pnpm install",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
Remove failing `mysql-client` devcontainer feature and install `mariadb-client` via `apt` to fix container creation.

---
<a href="https://cursor.com/background-agent?bcId=bc-16b9aa06-6cb4-443e-ac0d-d6b5bc06e84c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-16b9aa06-6cb4-443e-ac0d-d6b5bc06e84c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

