### PR TITLE
Configure devcontainer for auto-start and port forwarding

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,12 @@
   },
   "remoteUser": "vscode",
   "postCreateCommand": "sudo apt-get update -y && sudo apt-get install -y mysql-client && npm install -g pnpm && cd apps/web && pnpm install",
+  "forwardPorts": [3000, 8000],
+  "portsAttributes": {
+    "3000": { "label": "Web (Vite)", "onAutoForward": "openBrowser", "protocol": "http" },
+    "8000": { "label": "API (PHP)", "onAutoForward": "openBrowser", "protocol": "http" }
+  },
+  "postAttachCommand": "bash .devcontainer/start.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/start.sh
+++ b/.devcontainer/start.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Web (Vite) — runs on 3000
+if [ -d "apps/web" ]; then
+  pushd apps/web >/dev/null
+  # ensure deps (idempotent)
+  command -v pnpm >/dev/null || npm install -g pnpm
+  pnpm install
+  # host 0.0.0.0 so Codespaces can port-forward
+  nohup pnpm dev -- --host 0.0.0.0 --port 3000 >/tmp/web.out 2>&1 &
+  popd >/dev/null
+fi
+
+# API (Laravel) — runs on 8000
+if [ -d "apps/api" ]; then
+  # composer may not exist in minimal images; install if needed
+  if ! command -v composer >/dev/null 2>&1; then
+    sudo apt-get update -y
+    sudo apt-get install -y composer
+  fi
+  composer install -d apps/api
+  # serve public dir; bind to 0.0.0.0 for forwarding
+  nohup php -S 0.0.0.0:8000 -t apps/api/public >/tmp/api.out 2>&1 &
+fi
+
+echo "Started: web -> :3000, api -> :8000"


### PR DESCRIPTION
Configure Codespaces to auto-start web and API servers on attach and automatically open their URLs in the browser.

---
<a href="https://cursor.com/background-agent?bcId=bc-e3eec7b5-9970-40e8-b7ff-b77f17ecbf66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e3eec7b5-9970-40e8-b7ff-b77f17ecbf66"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

