### PR TITLE
Automate fullstack php node devcontainer setup

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,32 +1,26 @@
 set -e
-# ----- 共通ツール -----
 sudo apt-get update -y
 sudo apt-get install -y curl unzip
-# composer（なければ）
 if ! command -v composer >/dev/null 2>&1; then
   php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
   php composer-setup.php --install-dir=/usr/local/bin --filename=composer
   rm -f composer-setup.php
 fi
-# Node系
 npm i -g pnpm
-# ----- Web -----
+
+# Webセットアップ
 if [ -d apps/web ]; then
   cd apps/web
   npm i || pnpm i || true
-  # Vite のHMRが github.dev でも安定するように
-  if [ -f vite.config.ts ] && ! grep -q "clientPort: 443" vite.config.ts; then
-    sed -i 's/server:\s*{[^}]*}/server: { host: true, port: 3000, strictPort: true, hmr: { clientPort: 443 } }/g' vite.config.ts || true
-  fi
   cd - >/dev/null
 fi
-# ----- API(Laravel想定) -----
+
+# APIセットアップ
 if [ -d apps/api ]; then
   cd apps/api
   [ -f .env ] || cp .env.example .env || true
   composer install --no-interaction --prefer-dist || true
   php artisan key:generate || true
-  # CORS/セッションを github.dev に合わせる
   grep -q '^SESSION_DOMAIN=' .env || echo "SESSION_DOMAIN=.github.dev" >> .env
   grep -q '^SANCTUM_STATEFUL_DOMAINS=' .env || echo "SANCTUM_STATEFUL_DOMAINS=.github.dev" >> .env
   cd - >/dev/null

--- a/.devcontainer/start.sh
+++ b/.devcontainer/start.sh
@@ -1,28 +1,24 @@
 set -e
-# Codespaces公開URLを取得
 API_URL=$(gp url 8000)
 FRONT_URL=$(gp url 3000)
 
-# API 起動（Laravel）
+# API 起動 (Laravel)
 if [ -d apps/api ]; then
   cd apps/api
-  # APP_URL を公開URLに合わせる
   if grep -q '^APP_URL=' .env; then
     sed -i "s|^APP_URL=.*|APP_URL=${API_URL}|" .env
   else
     echo "APP_URL=${API_URL}" >> .env
   fi
   php artisan config:clear || true
-  php artisan route:clear || true
   php artisan serve --host=0.0.0.0 --port=8000 >/tmp/api.log 2>&1 &
   cd - >/dev/null
 fi
 
-# Web 起動（Vite）
+# Web 起動 (Vite)
 if [ -d apps/web ]; then
   cd apps/web
   echo "VITE_API_BASE=${API_URL}" > .env.local
-  # --host/--strictPortで外部から確実に見えるように
   npm run dev -- --host --port 3000 --strictPort >/tmp/web.log 2>&1 &
   cd - >/dev/null
 fi


### PR DESCRIPTION
Add devcontainer configuration to automate PHP (Laravel) and Node (Vite) environment setup and service startup in Codespaces.

---
<a href="https://cursor.com/background-agent?bcId=bc-da364dae-c2e1-4ec0-b519-176fa1069c37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-da364dae-c2e1-4ec0-b519-176fa1069c37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

